### PR TITLE
workaround for stat_float_times AttributeError on linux'

### DIFF
--- a/src/pytddmon.py
+++ b/src/pytddmon.py
@@ -640,7 +640,10 @@ def parse_commandline():
 
 
 def build_monitor(file_finder):
-    os.stat_float_times(False)
+    try:
+        os.stat_float_times(False)
+    except AttributeError:
+        pass #AttributeError: module 'os' has no attribute 'stat_float_times'
 
     def get_file_size(file_path):
         stat = os.stat(file_path)


### PR DESCRIPTION
Validateur : ben5962 <leclere.corentin@gmail.com>
hello objarni.
i like your pytddmon a lot.
this version does not work on linux: 
AttributeError: module 'os' has no attribute 'stat_float_times'
i ve put it in a try....except block to prenvent the code from hanging